### PR TITLE
enable xvfb

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -113,6 +113,11 @@ in
                 done
               ''
             );
+            umountTmpX11.text = ''
+              # this will be created again rw by systemd.tmpfiles.rules
+              echo "unmounting readonly /tmp/.X11-unix..."
+              umount /tmp/.X11-unix/
+            '';
             populateBin = lib.mkIf cfg.populateBin (stringAfter [ ] ''
               echo "setting up /bin..."
               ln -sf /init /bin/wslpath
@@ -142,7 +147,10 @@ in
 
             # Link the X11 socket into place. This is a no-op on a normal setup,
             # but helps if /tmp is a tmpfs or mounted from some other location.
-            tmpfiles.rules = [ "L /tmp/.X11-unix - - - - ${cfg.wslConf.automount.root}/wslg/.X11-unix" ];
+            tmpfiles.rules = [
+              "d /tmp/.X11-unix 1777 root root -"
+              "L /tmp/.X11-unix/X0 - - - - ${cfg.wslConf.automount.root}/wslg/.X11-unix/X0"
+            ];
           };
 
           # Start a systemd user session when starting a command through runuser


### PR DESCRIPTION
  Currently, /tmp/.X11-unix is a ro bind mount, this makes starting
other X servers (Xvfb, vnc, etc) impossible. This patch unmounts the bind mount, makes the directory writable, and creates a symlink to the wslg passthrough socket.